### PR TITLE
API Bump to 3.0.0-ALPHA10

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,6 +2,6 @@ name: MOTDShuffle
 main: MOTDShuffle\Main
 load: STARTUP
 version: 1.1.0
-api: 3.0.0-ALPHA9
+api: [3.0.0-ALPHA9, 3.0.0-ALPHA10]
 author: TheDeibo
 description: MOTD Upon MCPE Client Call.


### PR DESCRIPTION
Title explains it all.  No major changes that affect MOTDShuffle with changes to 3.0.0-ALPHA10.