### PR TITLE
PHP 8.2 fix

### DIFF
--- a/src/HBIDamian/MOTDShuffle/Main.php
+++ b/src/HBIDamian/MOTDShuffle/Main.php
@@ -7,12 +7,14 @@ use pocketmine\utils\Config;
 
 class Main extends PluginBase implements Listener {
 
+	private Config $getMainConfig;
+
     public function onEnable(): void {
         @mkdir($this->getDataFolder());
         $this->saveResource("config.yml");        
         $this->getMainConfig = new Config($this->getdatafolder() . "config.yml", Config::YAML);
         $configVersion = "1.0.0";
-        if (is_int($this->getMainConfig()->get("MOTD Delay")) == true){
+        if (is_int($this->getMainConfig()->get("MOTD Delay"))){
             if ($this->getMainConfig->get("Config Version") !== $configVersion){
                 $this->getLogger()->error("The config version is invalid. Please update the config.yml.");
             } else {
@@ -23,7 +25,7 @@ class Main extends PluginBase implements Listener {
         } 
     }
 
-    public function getMainConfig(){
+    public function getMainConfig() : Config{
         return $this->getMainConfig;
     }
 }

--- a/src/HBIDamian/MOTDShuffle/Main.php
+++ b/src/HBIDamian/MOTDShuffle/Main.php
@@ -7,7 +7,7 @@ use pocketmine\utils\Config;
 
 class Main extends PluginBase implements Listener {
 
-	private Config $getMainConfig;
+    private Config $getMainConfig;
 
     public function onEnable(): void {
         @mkdir($this->getDataFolder());

--- a/src/HBIDamian/MOTDShuffle/SendMOTD.php
+++ b/src/HBIDamian/MOTDShuffle/SendMOTD.php
@@ -6,7 +6,7 @@ use pocketmine\utils\TextFormat;
 class SendMOTD extends Task {
 
     private Main $plugin;
-	private int $line;
+    private int $line;
 
     public function __construct(Main $plugin){
         $this->plugin = $plugin;

--- a/src/HBIDamian/MOTDShuffle/SendMOTD.php
+++ b/src/HBIDamian/MOTDShuffle/SendMOTD.php
@@ -5,7 +5,8 @@ use pocketmine\utils\TextFormat;
 
 class SendMOTD extends Task {
 
-    private $plugin;
+    private Main $plugin;
+	private int $line;
 
     public function __construct(Main $plugin){
         $this->plugin = $plugin;
@@ -46,11 +47,11 @@ class SendMOTD extends Task {
         } else {
             //Error if user didn't specify "On or Off"
             $this->getPlugin()->getLogger()->error("A error has occured! Make sure the setting is right in the §cconfig.yml§4.");
-            $this->getPlugin()->getScheduler()->cancelTask($this->getTaskId()); //Cancelled to prevent console spam ;)
+			$this->getHandler()->cancel(); //Cancelled to prevent console spam ;)
         }
     }
     
-    public function getPlugin(){
+    public function getPlugin() : Main{
 	   return $this->plugin;
     }
 }

--- a/src/HBIDamian/MOTDShuffle/SendMOTD.php
+++ b/src/HBIDamian/MOTDShuffle/SendMOTD.php
@@ -13,12 +13,12 @@ class SendMOTD extends Task {
         $this->line = -1;
     }
 
-	public function replaceVars(string $str, array $vars): string{
-		foreach ($vars as $key => $value){
-			$str = str_replace('{' . $key . '}', (string) $value, $str);
-		}
-		return $str;
+    public function replaceVars(string $str, array $vars): string{
+	foreach ($vars as $key => $value){
+	    $str = str_replace('{' . $key . '}', (string) $value, $str);
 	}
+	return $str;
+    }
 
     public function onRun(): void{
         $getMOTD = $this->getPlugin()->getMainConfig()->get("MOTD Message");
@@ -47,11 +47,11 @@ class SendMOTD extends Task {
         } else {
             //Error if user didn't specify "On or Off"
             $this->getPlugin()->getLogger()->error("A error has occured! Make sure the setting is right in the §cconfig.yml§4.");
-			$this->getHandler()->cancel(); //Cancelled to prevent console spam ;)
+	    $this->getHandler()->cancel(); //Cancelled to prevent console spam ;)
         }
     }
     
     public function getPlugin() : Main{
-	   return $this->plugin;
+	return $this->plugin;
     }
 }


### PR DESCRIPTION
Since PHP 8.2 doesnt allow creation of dynamic property without apply the tag #[AllowDynamicProperties]. This PR will fix that problem also no other problems have been found in PHP 8.1.
